### PR TITLE
#3050488 - Support ECP/ACH transaction

### DIFF
--- a/src/Bluesnap/Adapter.php
+++ b/src/Bluesnap/Adapter.php
@@ -59,6 +59,7 @@ class Adapter
         {
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model);
+
             $response = Api::post($endpoint, $data, $id_in_header);
 
             if ($id_in_header)
@@ -97,6 +98,7 @@ class Adapter
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model, $id);
             $endpoint = $id_in_url ? $endpoint .'/'. $id : $endpoint;
+
             $response = Api::put($endpoint, $data);
             $model = Utility::setupModel($model, $response);
 

--- a/src/Bluesnap/Adapter.php
+++ b/src/Bluesnap/Adapter.php
@@ -59,7 +59,6 @@ class Adapter
         {
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model);
-
             $response = Api::post($endpoint, $data, $id_in_header);
 
             if ($id_in_header)
@@ -98,7 +97,6 @@ class Adapter
             $data = Utility::objectToArray($data);
             $endpoint = Utility::getModelEndpoint($model, $id);
             $endpoint = $id_in_url ? $endpoint .'/'. $id : $endpoint;
-
             $response = Api::put($endpoint, $data);
             $model = Utility::setupModel($model, $response);
 

--- a/src/Bluesnap/AltTransaction.php
+++ b/src/Bluesnap/AltTransaction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bluesnap;
+
+/**
+ * Class CardTransaction
+ */
+class AltTransaction
+{
+    public static function get($id = null)
+    {
+        return Adapter::get('AltTransaction', $id);
+    }
+
+    public static function create($data)
+    {
+        return Adapter::create('AltTransaction', $data, [
+            'id_in_header' => false
+        ]);
+    }
+
+    public static function update($id, $data)
+    {
+        return Adapter::update('AltTransaction', $id, $data, [
+            'id_in_url' => false
+        ]);
+    }
+}

--- a/src/Bluesnap/Api.php
+++ b/src/Bluesnap/Api.php
@@ -54,6 +54,7 @@ class Api
     public static function post($endpoint, $data, $id_in_header)
     {
         $client = self::getClient();
+
     //    $clientHandler = $client->getConfig('handler');
     //    $tapMiddleware = Middleware::tap(function ($request) {
     //        echo "Request data:\n\ncontent-type: ". $request->getHeaderLine('Content-Type') ."\n";

--- a/src/Bluesnap/Api.php
+++ b/src/Bluesnap/Api.php
@@ -22,8 +22,9 @@ class Api
             'base_uri' => $base_url,
 //            'timeout'  => 10.0,
             'auth' => $credentials,
+            'bluesnap-version' => '3.0',
             'headers' => [
-                'Accept' => 'application/json'
+                'Accept' => 'application/json',
             ]
         ]);
     }
@@ -53,7 +54,6 @@ class Api
     public static function post($endpoint, $data, $id_in_header)
     {
         $client = self::getClient();
-
     //    $clientHandler = $client->getConfig('handler');
     //    $tapMiddleware = Middleware::tap(function ($request) {
     //        echo "Request data:\n\ncontent-type: ". $request->getHeaderLine('Content-Type') ."\n";

--- a/src/Bluesnap/Models/AltTransaction.php
+++ b/src/Bluesnap/Models/AltTransaction.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Bluesnap\Models;
+
+/**
+ * Class AltTransaction
+ */
+class AltTransaction extends Model
+{
+    public function __construct($data = null)
+    {
+        parent::__construct($data, 'transactionId');
+    }
+
+    protected $children = ['transactionMetaData' => self::ITEM, 'vendorInfo' => self::ITEM];
+
+
+    /**
+     * Amount to be charged in the transaction, including decimal points.
+     * @var string
+     */
+    public $amount;
+
+    /**
+     * Enter ECOMMERCE for a one-time transaction or RECURRING for a recurring transaction.
+     * @var string
+     */
+    public $recurringTransaction;
+
+    /**
+     * Merchant's unique ID for a new transaction. Length: 1..50
+     * @var string
+     */
+    public $merchantTransactionId;
+
+    /**
+     * Description of the transaction, which appears on the shopper's credit card statement.
+     * @var string $softDescriptor
+     */
+    public $softDescriptor;
+
+    /**
+     * ID of an existing vaulted shopper.
+     * @var string
+     */
+    public $vaultedShopperId;
+
+    /**
+     * Currency code (ISO 4217) of the amount to be charged.
+     * @var string
+     */
+    public $currency;
+
+    /**
+     * @var TransactionMetaData
+     */
+    public $transactionMetaData;
+
+    /**
+     * @var TransactionFraudInfo
+     */
+    public $transactionFraudInfo;
+}

--- a/src/Bluesnap/Utility.php
+++ b/src/Bluesnap/Utility.php
@@ -56,6 +56,7 @@ class Utility
             'SubscriptionCharge' => 'recurring/subscriptions/charges',
             'VaultedShopper' => 'vaulted-shoppers',
             'Vendor' => 'vendors',
+            'AltTransaction' => 'alt-transactions',
         ];
 
         return $models[$model];
@@ -76,7 +77,6 @@ class Utility
 
             return $models;
         }
-
         return new $class_path($data);
     }
 }


### PR DESCRIPTION
* Add support for Alternate Transaction API (ACH/ECP)
* Updated the API version to use to be 3.0 as multiple ACH for vaulted shopper is supported only in API version 3. Will have to check hosted payment fields payment 