### PR TITLE
Ad an object for EcpDetails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bluesnap/Models/EcpDetails.php
+++ b/src/Bluesnap/Models/EcpDetails.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bluesnap\Models;
+
+/**
+ * Class EcpDetails
+ */
+class EcpDetails extends Model
+{
+    public function __construct($data = null)
+    {
+        parent::__construct($data);
+    }
+
+    protected $children = ['ecp' => self::ITEM, 'billingContactInfo' => self::ITEM];
+
+    /**
+     * @var Ecp
+     */
+    public $ecp;
+
+    /**
+     * @var BillingContactInfo
+     */
+    public $billingContactInfo;
+
+    /**
+     * @var string
+     */
+    public $status;
+}

--- a/src/Bluesnap/Models/PaymentSources.php
+++ b/src/Bluesnap/Models/PaymentSources.php
@@ -12,7 +12,7 @@ class PaymentSources extends Model
         parent::__construct($data);
     }
 
-    protected $children = ['creditCardInfo' => self::COLLECTION, 'ecpInfo' => self::COLLECTION];
+    protected $children = ['creditCardInfo' => self::COLLECTION, 'ecpInfo' => self::COLLECTION, 'ecpDetails' => self::COLLECTION];
 
     /**
      * @var CreditCardInfo[]
@@ -23,4 +23,9 @@ class PaymentSources extends Model
      * @var EcpInfo[]
      */
     public $ecpInfo;
+
+    /**
+     * @var EcpDetails[]
+     */
+    public $ecpDetails;
 }


### PR DESCRIPTION
There is an object already for EcpInfo, but many requests work with the EcpDetails object within payment sources. Add an object so that data can be properly converted to objects automatically, like other ones.